### PR TITLE
Virtualenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ _build/*
 __pycache__
 .netlify
 node_modules
+
+# ignore common virtual environment names
+venv
+env

--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,8 @@ It is Python-based, with content in `ReStructuredText (rst) <https://docutils.so
 Running locally
 ---------------
 
+We recommend using a virtual environment like `virtualenv <https://virtualenv.pypa.io/en/latest/>`_ or `venv <https://docs.python.org/3/library/venv.html>`_.
+
 Install the dependencies::
 
     pip install -r requirements.txt


### PR DESCRIPTION
Two additions to the .gitignore: `env` and `venv`.
These are commonly used as folder names when using [venv](https://docs.python.org/3/library/venv.html) or [virtualenv](https://virtualenv.pypa.io/en/latest/) 
And add a recommendation to the README for folks to use a virtual environment.